### PR TITLE
Add playlists feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Easily add watch party support to your website by redirecting the user to Metast
 - [x] Port Metastream from Electron to a web app ([#94](https://github.com/samuelmaddock/metastream/issues/94))
 - [x] Improve UX and stability
 - [x] Add favorites/bookmarks ([#21](https://github.com/samuelmaddock/metastream/issues/21))
-- [ ] Add playlists
+- [x] Add playlists
 - [x] Add audio mode ([#22](https://github.com/samuelmaddock/metastream/issues/22))
 
 Have a feature in mind? Make a request by [creating a GitHub issue](https://github.com/samuelmaddock/metastream/issues).

--- a/packages/metastream-app/src/components/lobby/MediaList.tsx
+++ b/packages/metastream-app/src/components/lobby/MediaList.tsx
@@ -26,6 +26,7 @@ import { withNamespaces, WithNamespaces } from 'react-i18next'
 import { sendMediaRequest } from 'lobby/actions/media-request'
 import { setSetting } from 'actions/settings'
 import { addFavorite } from 'reducers/favorites'
+import { addPlaylistItem } from 'reducers/playlists'
 
 interface IProps {
   className?: string
@@ -49,6 +50,7 @@ interface DispatchProps {
   toggleQueueLock(): void
   toggleCollapsed(): void
   addFavorite(media: IMediaItem): void
+  addPlaylistItem(media: IMediaItem): void
 }
 
 type Props = IProps & IConnectedProps & DispatchProps & WithNamespaces
@@ -109,6 +111,10 @@ class _MediaList extends Component<Props> {
               {
                 label: t('addFavorite'),
                 onClick: () => this.props.addFavorite(media),
+              },
+              {
+                label: t('addPlaylist'),
+                onClick: () => this.props.addPlaylistItem(media),
               },
               {
                 label: t('duplicate'),
@@ -217,6 +223,9 @@ export const MediaList = withNamespaces()(
       },
       addFavorite(media) {
         dispatch(addFavorite(media))
+      },
+      addPlaylistItem(media) {
+        dispatch(addPlaylistItem(media))
       },
     }),
   )(_MediaList),

--- a/packages/metastream-app/src/components/lobby/PlaylistsList.tsx
+++ b/packages/metastream-app/src/components/lobby/PlaylistsList.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { ListOverlay } from './ListOverlay'
+import { IMediaItem } from '../../lobby/reducers/mediaPlayer'
+import { IAppState } from '../../reducers'
+import { removePlaylistItem } from '../../reducers/playlists'
+import { MediaItem } from '../media/MediaItem'
+import MenuItem from '@material-ui/core/MenuItem'
+import { WithNamespaces, withNamespaces } from 'react-i18next'
+
+interface ConnectedProps {
+  playlists: IMediaItem[]
+}
+
+interface DispatchProps {
+  removePlaylistItem(id: string): void
+}
+
+type Props = ConnectedProps & DispatchProps & WithNamespaces
+
+const _PlaylistsList: React.SFC<Props> = ({ playlists, t, removePlaylistItem }) => {
+  return (
+    <ListOverlay
+      id="playlists"
+      title={t('playlists')}
+      tagline={playlists.length ? `${playlists.length}` : undefined}
+      renderMenuOptions={(item, close) => (
+        <MenuItem
+          onClick={() => {
+            removePlaylistItem(item.id)
+            close()
+          }}
+        >
+          {t('remove')}
+        </MenuItem>
+      )}
+    >
+      {playlists.map((media) => (
+        <MediaItem key={media.id} media={media} onClickMenu={() => {}} />
+      ))}
+    </ListOverlay>
+  )
+}
+
+export const PlaylistsList = withNamespaces()(
+  connect<ConnectedProps, DispatchProps, {}, IAppState>(
+    (state) => ({ playlists: state.playlists.items }),
+    (dispatch) => ({ removePlaylistItem: (id) => dispatch(removePlaylistItem(id)) })
+  )(_PlaylistsList)
+)

--- a/packages/metastream-app/src/components/sidebar/index.tsx
+++ b/packages/metastream-app/src/components/sidebar/index.tsx
@@ -9,6 +9,7 @@ import { setLobbyModal } from 'actions/ui'
 import { LobbyModal } from 'reducers/ui'
 import { MediaList } from 'components/lobby/MediaList'
 import { FavoritesList } from 'components/lobby/FavoritesList'
+import { PlaylistsList } from 'components/lobby/PlaylistsList'
 import { PanelHeader } from 'components/lobby/PanelHeader'
 import { ChatLayoutButton } from 'components/chat/ChatLayoutButton'
 import { t } from 'locale'
@@ -43,6 +44,7 @@ export const Sidebar: React.SFC<Props> = ({ className, popup }) => {
         collapsible
       />
       <FavoritesList className={styles.list} />
+      <PlaylistsList className={styles.list} />
       <PanelHeader title={t('chat')} action={popup ? null : <ChatLayoutButton />} />
       <Chat className={styles.chat} showDockOption={false} />
     </div>

--- a/packages/metastream-app/src/locale/en-US.ts
+++ b/packages/metastream-app/src/locale/en-US.ts
@@ -46,6 +46,7 @@ export default {
   donators: 'Donators',
   duplicate: 'Duplicate',
   addFavorite: 'Add to favorites',
+  addPlaylist: 'Add to playlist',
   embedBlocked:
     'To enable playback with <1>{{host}}</1>, Metastream must open the website in a popup.',
   endSessionTitle: 'End Session?',
@@ -144,6 +145,7 @@ export default {
   unlimited: 'Unlimited',
   unlockQueue: 'Unlock queue',
   favorites: 'Favorites',
+  playlists: 'Playlists',
   updateAvailable:
     'An update for Metastream is available. Press the UPDATE button in the top-right to receive the update.',
   username: 'Username',

--- a/packages/metastream-app/src/reducers/index.ts
+++ b/packages/metastream-app/src/reducers/index.ts
@@ -5,6 +5,7 @@ import { merge } from 'lodash-es'
 import { settings, ISettingsState } from './settings'
 import { ui, IUIState } from './ui'
 import { favorites, IFavoritesState } from './favorites'
+import { playlists, IPlaylistsState } from './playlists'
 
 import { ILobbyNetState, lobbyReducers } from '../lobby/reducers'
 import { AnyAction } from 'redux'
@@ -20,6 +21,7 @@ import { History } from 'history'
 export interface IAppState extends ILobbyNetState {
   settings: ISettingsState
   favorites: IFavoritesState
+  playlists: IPlaylistsState
   ui: IUIState
   router: RouterState
 }
@@ -36,6 +38,7 @@ export const createReducer = (history: History) => {
     ...lobbyReducers,
     settings,
     favorites,
+    playlists,
     ui
   })
 

--- a/packages/metastream-app/src/reducers/playlists.ts
+++ b/packages/metastream-app/src/reducers/playlists.ts
@@ -1,0 +1,28 @@
+import { Reducer } from 'redux'
+import { createAction } from '@reduxjs/toolkit'
+import { IMediaItem } from '../lobby/reducers/mediaPlayer'
+
+export interface IPlaylistsState {
+  items: IMediaItem[]
+}
+
+export const addPlaylistItem = createAction<IMediaItem>('playlists/add')
+export const removePlaylistItem = createAction<string>('playlists/remove')
+
+const initialState: IPlaylistsState = {
+  items: []
+}
+
+export const playlists: Reducer<IPlaylistsState> = (
+  state: IPlaylistsState = initialState,
+  action: any
+) => {
+  if (addPlaylistItem.match(action)) {
+    if (!state.items.find((item) => item.url === action.payload.url)) {
+      return { ...state, items: [...state.items, action.payload] }
+    }
+  } else if (removePlaylistItem.match(action)) {
+    return { ...state, items: state.items.filter((item) => item.id !== action.payload) }
+  }
+  return state
+}

--- a/packages/metastream-app/src/store/persistStore.ts
+++ b/packages/metastream-app/src/store/persistStore.ts
@@ -3,7 +3,7 @@ import storage from 'redux-persist/lib/storage'
 import autoMergeLevel2 from 'redux-persist/es/stateReconciler/autoMergeLevel2'
 import { createMigrate, PersistedState } from 'redux-persist'
 
-const whitelist: (keyof IAppState)[] = ['mediaPlayer', 'settings', 'favorites']
+const whitelist: (keyof IAppState)[] = ['mediaPlayer', 'settings', 'favorites', 'playlists']
 
 const migrations: { [version: number]: (state: any) => any } = {
   2: function removeDefaultAvatarMigration(state) {


### PR DESCRIPTION
## Summary
- implement playlists with Redux slice and list overlay
- add menu option to add items to playlists
- persist playlists in local storage
- mark playlists as complete in Roadmap
- add translation strings for playlists

## Testing
- `npx jest --version`
- `yarn --cwd packages/metastream-app test:unit` *(fails: Output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68400da32a20833099826162c34b7a33